### PR TITLE
handle ACTION_CANCEL, prevent swipe menu from stuck in the middle

### DIFF
--- a/library/src/main/java/com/baoyz/swipemenulistview/SwipeMenuLayout.java
+++ b/library/src/main/java/com/baoyz/swipemenulistview/SwipeMenuLayout.java
@@ -185,6 +185,7 @@ public class SwipeMenuLayout extends FrameLayout {
 			}
 			swipe(dis);
 			break;
+		case MotionEvent.ACTION_CANCEL:
 		case MotionEvent.ACTION_UP:
 			if ((isFling || Math.abs(mDownX - event.getX()) > (mMenuView.getWidth() / 2)) &&
 					Math.signum(mDownX - event.getX()) == mSwipeDirection) {

--- a/library/src/main/java/com/baoyz/swipemenulistview/SwipeMenuListView.java
+++ b/library/src/main/java/com/baoyz/swipemenulistview/SwipeMenuListView.java
@@ -252,6 +252,11 @@ public class SwipeMenuListView extends ListView {
                     return true;
                 }
                 break;
+            case MotionEvent.ACTION_CANCEL:
+                if (mTouchState == TOUCH_STATE_X) {
+                    if (mTouchView != null) mTouchView.onSwipe(ev);
+                }
+                break;
         }
         return super.onTouchEvent(ev);
     }


### PR DESCRIPTION
In my case ACTION_UP event would be missing sometimes and the swipe menu stuck in the middle. This is trying to fix the problem by handling ACTION_CANCEL event.
