### PR TITLE
Update SimpleActivity.java

### DIFF
--- a/demo/src/main/java/com/baoyz/swipemenulistview/demo/SimpleActivity.java
+++ b/demo/src/main/java/com/baoyz/swipemenulistview/demo/SimpleActivity.java
@@ -71,7 +71,6 @@ public class SimpleActivity extends Activity {
         mListView = (SwipeMenuListView) findViewById(R.id.listView);
 
         mAdapter = new AppAdapter();
-        mListView.setAdapter(mAdapter);
 
         // step 1. create a MenuCreator
         SwipeMenuCreator creator = new SwipeMenuCreator() {
@@ -111,6 +110,8 @@ public class SimpleActivity extends Activity {
         };
         // set creator
         mListView.setMenuCreator(creator);
+
+        mListView.setAdapter(mAdapter);
 
         // step 2. listener item click event
         mListView.setOnMenuItemClickListener(new SwipeMenuListView.OnMenuItemClickListener() {


### PR DESCRIPTION
SwipeMenuListView中执行setAdapter，会调用SwipeMenuAdapter中的createMenu方法，如果此时mMenuCreator仍为空，会导致创建侧滑失败，参考[这里](https://goo.gl/2fp9qQ)，先setMenuCreator再setAdapter鲁棒性更强。
